### PR TITLE
Tag files are formatted in markdown and named .markdown.

### DIFF
--- a/gitmark.py
+++ b/gitmark.py
@@ -83,13 +83,14 @@ class gitMark(object):
         
     def saveTagData(self, tag, url, title, content_filename):
         try:
-            tag_writer = csv.writer(open('%s%s' % (TAG_PATH, tag), 'a'))
+            f = open('%s%s.markdown' % (TAG_PATH, tag), 'a')
         except IOError:
             os.mkdir(TAG_PATH,0755)
-            tag_writer = csv.writer(open('%s%s' % (TAG_PATH, tag), 'a'))
-            
-        tag_writer.writerow([url, title, content_filename])
-        return '%s%s' % (TAG_PATH, tag)
+            f = open('%s%s.markdown' % (TAG_PATH, tag), 'a')
+
+        line = '[%s](%s), %s  \n' % (title, url, content_filename)
+        f.write(line)
+        return '%s%s.markdown' % (TAG_PATH, tag)
 
     def parseTitle(self, content):
         re_htmltitle = re.compile(".*<title>(.*)</title>.*")

--- a/gitmark.py
+++ b/gitmark.py
@@ -67,7 +67,11 @@ class gitMark(object):
         subprocess.call(['git', 'commit', '-m', msg], shell=USE_SHELL)
         
     def gitPush(self):
-        pipe = subprocess.Popen("git push origin master", shell=True)
+        # pipe = subprocess.Popen("git push origin master", shell=True)
+        # I'm using a separate branch of gitmarks to store my data.
+        # The active "data" branch is defined in settings.py (defaults to "master")
+		command = "git push origin %" % GIT_BRANCH
+        pipe = subprocess.Popen(command, shell=True)
         pipe.wait()
         
     def saveContent(self, filename, content):
@@ -88,8 +92,8 @@ class gitMark(object):
             os.mkdir(TAG_PATH,0755)
             f = open('%s%s.markdown' % (TAG_PATH, tag), 'a')
 
-        line = '[%s](%s), %s  \n' % (title, url, content_filename)
-        f.write(line)
+        line = '[%s](%s), %s  \n' % (title.decode('utf-8'), url, content_filename)
+        f.write(line.encode('utf-8'))
         return '%s%s.markdown' % (TAG_PATH, tag)
 
     def parseTitle(self, content):

--- a/gitmark.py
+++ b/gitmark.py
@@ -70,7 +70,7 @@ class gitMark(object):
         # pipe = subprocess.Popen("git push origin master", shell=True)
         # I'm using a separate branch of gitmarks to store my data.
         # The active "data" branch is defined in settings.py (defaults to "master")
-		command = "git push origin %" % GIT_BRANCH
+        command = "git push origin %s" % GIT_BRANCH
         pipe = subprocess.Popen(command, shell=True)
         pipe.wait()
         

--- a/settings.py
+++ b/settings.py
@@ -3,3 +3,5 @@ TAG_PATH = 'tags/'
 CONTENT_PATH = 'content/'
 
 GITMARKS_WEB_PORT = 44865
+
+GIT_BRANCH = 'master'

--- a/settings.py
+++ b/settings.py
@@ -4,4 +4,4 @@ CONTENT_PATH = 'content/'
 
 GITMARKS_WEB_PORT = 44865
 
-GIT_BRANCH = 'master'
+GIT_BRANCH = 'mydata'


### PR DESCRIPTION
This makes it much easier to browse them on GitHub which renders .markdown files as HTML.
